### PR TITLE
Update ThriftClientPool.java

### DIFF
--- a/src/main/java/com/wealoha/thrift/ThriftClientPool.java
+++ b/src/main/java/com/wealoha/thrift/ThriftClientPool.java
@@ -1,6 +1,7 @@
 package com.wealoha.thrift;
 
 import java.lang.reflect.Proxy;
+import java.lang.reflect.InvocationTargetException
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -285,6 +286,12 @@ public class ThriftClientPool<T extends TServiceClient> {
                 Object result = method.invoke(client.iFace(), args);
                 success = true;
                 return result;
+            } catch (InvocationTargetException e) {
+                // Invocation Exceptions are thrown when an error occurs inside the invoke call.  
+                // For the purposes of this proxy class, the InvocationException should be unwrapped
+                // and the underlying target exception should be thrown instead. This way, the Proxy 
+                // instance will recognized the Checked exception and throw that back to the calling method.
+                throw e.getTargetException();
             } catch (Throwable e) {
                 logger.warn("invoke fail", e);
                 throw e;


### PR DESCRIPTION
Fixing the error handling of the proxy instance so the underlying thrift exception can be thrown directly back to the calling method, instead of being wrapped in a InvocationTargetException inside of a UndeclaredThrowableException.